### PR TITLE
feat(health-check): add health checks for SQL Server and managed memory

### DIFF
--- a/Ecom.Presentation/Controllers/HealthCheckController.cs
+++ b/Ecom.Presentation/Controllers/HealthCheckController.cs
@@ -1,0 +1,47 @@
+﻿using Asp.Versioning;
+using Ecom.Presentation.Helpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Ecom.Presentation.Controllers
+{
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    public class HealthCheckController : ControllerBase
+    {
+        private readonly HealthCheckService _healthCheckService;
+
+        public HealthCheckController(HealthCheckService healthCheckService)
+        {
+            _healthCheckService = healthCheckService;
+        }
+
+
+        [HttpGet()]
+        public async Task Health()
+        {
+            var report = await _healthCheckService.CheckHealthAsync();
+
+            await HealthCheckResponseWriter.WriteJsonResponse(HttpContext, report);
+        }
+
+        [HttpGet("live")]
+        public IActionResult Liveness()
+        {
+            return Ok(new
+            {
+                status = "Healthy",
+                description = "Liveness check - the app is running"
+            });
+        }
+
+        [HttpGet("ready")]
+        public async Task Readiness()
+        {
+            var report = await _healthCheckService.CheckHealthAsync(h => h.Tags.Contains("ready"));
+
+            await HealthCheckResponseWriter.WriteJsonResponse(HttpContext, report);
+        }
+    }
+}

--- a/Ecom.Presentation/Ecom.Presentation.csproj
+++ b/Ecom.Presentation/Ecom.Presentation.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Ecom.Presentation/Extensions/PresentationRegisteration.cs
+++ b/Ecom.Presentation/Extensions/PresentationRegisteration.cs
@@ -1,4 +1,6 @@
 ﻿using Asp.Versioning;
+using Ecom.Presentation.Helpers;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Threading.RateLimiting;
 
 namespace Ecom.Presentation.Extensions
@@ -79,6 +81,21 @@ namespace Ecom.Presentation.Extensions
                 options.GroupNameFormat = "'v'VVV";       // Format for versioned API groups
                 options.SubstituteApiVersionInUrl = true; // Substitute version in URL
             });
+
+            #endregion
+
+
+            // register the health checks in services container 
+            #region Health Check Configurations
+
+            services.AddHealthChecks()
+                      .AddSqlServer(
+                          connectionString: configuration.GetConnectionString("EcomDatabase"),
+                          healthQuery: "SELECT 1;", // Query to check database health.
+                          name: "sqlserver",
+                          failureStatus: HealthStatus.Degraded, // Degraded health status if the check fails.
+                          tags: new[] { "db", "sql" })
+                      .AddCheck("Memory", new ManagedMemoryHealthCheck(1024 * 1024 * 1024)); // A custom health check for managed memory. 
 
             #endregion
 

--- a/Ecom.Presentation/Helpers/HealthCheckResponseWriter.cs
+++ b/Ecom.Presentation/Helpers/HealthCheckResponseWriter.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Ecom.Presentation.Helpers
+{
+    public static class HealthCheckResponseWriter
+    {
+        public static async Task WriteJsonResponse(HttpContext context, HealthReport report)
+        {
+            context.Response.ContentType = "application/json";
+            var json = new
+            {
+                status = report.Status.ToString(),
+                results = report.Entries.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => new
+                    {
+                        status = kvp.Value.Status.ToString(),
+                        description = kvp.Value.Description,
+                        exception = kvp.Value.Exception?.Message,
+                        duration = kvp.Value.Duration.ToString()
+                    })
+            };
+            await context.Response.WriteAsJsonAsync(json);
+        }
+    }
+}

--- a/Ecom.Presentation/Helpers/ManagedMemoryHealthCheck.cs
+++ b/Ecom.Presentation/Helpers/ManagedMemoryHealthCheck.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Ecom.Presentation.Helpers
+{
+    public class ManagedMemoryHealthCheck : IHealthCheck
+    {
+        private readonly long _maxMemoryThreshold;
+
+        public ManagedMemoryHealthCheck(long maxMemoryThreshold)
+        {
+            _maxMemoryThreshold = maxMemoryThreshold;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            long memoryUsage = GC.GetTotalMemory(false);
+
+            if (memoryUsage < _maxMemoryThreshold)
+            {
+                return Task.FromResult(HealthCheckResult.Healthy($"Memory usage is under control: {memoryUsage / 1024 / 1024} MB."));
+            }
+
+            return Task.FromResult(HealthCheckResult.Unhealthy($"Memory usage is too high: {memoryUsage / 1024 / 1024} MB."));
+        }
+    }
+}

--- a/Ecom.Presentation/Program.cs
+++ b/Ecom.Presentation/Program.cs
@@ -5,6 +5,7 @@ using Ecom.Infrastructure.Extensions;
 using Ecom.Presentation.Extensions;
 using Ecom.Presentation.Helpers;
 using Ecom.Presentation.Middlewares;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 
 namespace Ecom.Presentation
 {
@@ -72,6 +73,42 @@ namespace Ecom.Presentation
                     }
                 });
             }
+
+
+            #region Health Check
+
+            // Top-level route mapping for health checks
+            app.MapHealthChecks("/health", new HealthCheckOptions
+            {
+                ResponseWriter = HealthCheckResponseWriter.WriteJsonResponse
+            });
+
+
+            // Liveness probe, Purpose: Tells if the app is running.
+            app.MapHealthChecks("/health/live", new HealthCheckOptions
+            {
+                Predicate = _ => false, // No specific checks, just indicates the app is live
+                ResponseWriter = async (context, report) =>
+                {
+                    context.Response.ContentType = "application/json";
+                    var json = new
+                    {
+                        status = report.Status.ToString(),
+                        description = "Liveness check - the app is up"
+                    };
+                    await context.Response.WriteAsJsonAsync(json);
+                }
+            });
+
+
+            // Readiness probe, Tells if the app is ready to handle requests
+            app.MapHealthChecks("/health/ready", new HealthCheckOptions
+            {
+                Predicate = check => check.Tags.Contains("ready"), // Only run checks tagged as "ready"
+                ResponseWriter = HealthCheckResponseWriter.WriteJsonResponse
+            });
+
+            #endregion
 
             // Enable CORS
             app.UseCors("CORSPolicy");


### PR DESCRIPTION
- Registered health checks for SQL Server using a simple query to verify database connectivity.
- Implemented a custom managed memory health check to monitor application's memory usage.
- Added JSON response formatting for health check endpoints.
- Configured /health, /health/live, and /health/ready endpoints for general, liveness, and readiness probes.